### PR TITLE
Constant-time element erasure

### DIFF
--- a/mcts.h
+++ b/mcts.h
@@ -244,7 +244,8 @@ Node<State>* Node<State>::add_child(const Move& move, const State& state)
 	auto itr = moves.begin();
 	for (; itr != moves.end() && *itr != move; ++itr);
 	attest(itr != moves.end());
-	moves.erase(itr);
+	std::iter_swap(itr, moves.end() - 1);
+	moves.resize(moves.size() - 1);
 	return node;
 }
 


### PR DESCRIPTION
`std::vector::erase` preserves the order of elements and runs in O(n) time as a result, copying all elements after the removed element. I don't believe we care about the order of elements here, so I think we can get a constant-time erase via swap-and-shrink.

I haven't run any benchmarks to verify that this actually is faster in practice (we'd need to check a game with a fairly large branching factor at any rate so the move vector can be a reasonable size), I just thought swapping could be a neat hack here.