### PR TITLE
Resolve -Wreorder warnings

### DIFF
--- a/games/go.h
+++ b/games/go.h
@@ -44,9 +44,9 @@ public:
 
 
 	GoState():
-		player_to_move(1),
 		previous_board_hash_value(0),
-		depth(0)
+		depth(0),
+		player_to_move(1)
 	{ 
 		all_hash_values.insert(compute_hash_value());
 
@@ -58,9 +58,9 @@ public:
 	}
 
 	GoState(char board[M][N+1]):
-		player_to_move(1),
 		previous_board_hash_value(0),
-		depth(0)
+		depth(0),
+		player_to_move(1)
 	{
 		GoState<M, N> state;
 		for (int i = 0; i < M; ++i) {


### PR DESCRIPTION
[This warning](https://travis-ci.org/PetterS/monte-carlo-tree-search/builds/631173036#L296-L309) indicates that `GoState::player_to_move` appears in a different order in `GoState`'s definition than in its constructors. Quick fix, hopefully uncontroversial.